### PR TITLE
fix: correct syntax error in Jenkinsfile step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,6 @@ pipeline{
                             curl -X POST ${serviceUrl} \
                             -H "Content-Type: application/json" \
                             -d '${jsonPayload}' \
-                            -s -w '\nHTTP_CODE: %{http_code}'
                         """,
                         returnStdout: true
                     ).trim()


### PR DESCRIPTION
- Fixed an issue in the 'Merge -PR to Main' stage that caused the pipeline to fail.
- Adjusted the script syntax to ensure proper execution.
- Verified the pipeline runs successfully after the fix.