### PR TITLE
fix: correct syntax error in Jenkinsfile step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline{
                     echo"${responseJson}"
 
                     def responseObject = new groovy.json.JsonSlurper().parseText(responseJson) 
-                    def serializableMap = new HashMap(responseObject)    
+                    def serializableMap = [:] + responseObject    
                     if (serializableMap.success == true && serializableMap.message == "Ingestion successful.") {
                         echo "Test passed: Service returned success"
                     } else {


### PR DESCRIPTION
- Fixed an issue in the 'Merge -PR to Main' stage that caused the pipeline to fail.
- Adjusted the script syntax to ensure proper execution.